### PR TITLE
feat: add new chart display options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ DOM contained the visualization result.
 ```
 Bar chart style.
 
+##### barAttrs
+
+- Type: `Object`<br>
+- Default: `{}`
+
+Attributes set on each bar element.
+
 ##### width
 
 - Type: `Number`<br>
@@ -95,6 +102,13 @@ SVG width for bar chart.
 - Default: `500`
 
 SVG height for bar chart.
+
+##### responsive
+
+- Type: `boolean`<br>
+- Default: `false`
+
+Whether the chart should be automatically resized to fit its container. If true, `width` and `height` options are used for the initial sizing/SVG viewBox size.
 
 ##### margin
 
@@ -115,7 +129,28 @@ Color of bar.
 - Type: `string`<br>
 - Default: `brown`
 
-Color of bar hoverd.
+Color of bar hovered.
+
+##### showXAxis
+
+- Type: `boolean`<br>
+- Default: `true`
+
+Whether to show the X axis.
+
+##### showYAxis
+
+- Type: `boolean`<br>
+- Default: `true`
+
+Whether to show the Y axis.
+
+##### showValues
+
+- Type: `boolean`<br>
+- Default: `true`
+
+Whether to show values above each bar.
 
 ##### export
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,12 +20,22 @@ function bar() {
       _container = _ref$container === undefined ? '\n    <div id="container">\n      <h2>Bar Chart</h2>\n      <div id="chart"></div>\n    </div>\n  ' : _ref$container,
       _ref$style = _ref.style,
       _style = _ref$style === undefined ? '' : _ref$style,
+      _ref$barAttrs = _ref.barAttrs,
+      _barAttrs = _ref$barAttrs === undefined ? {} : _ref$barAttrs,
       _ref$width = _ref.width,
       _width = _ref$width === undefined ? 960 : _ref$width,
       _ref$height = _ref.height,
       _height = _ref$height === undefined ? 500 : _ref$height,
+      _ref$responsive = _ref.responsive,
+      _responsive = _ref$responsive === undefined ? false : _ref$responsive,
       _ref$margin = _ref.margin,
       _margin = _ref$margin === undefined ? { top: 20, right: 20, bottom: 20, left: 20 } : _ref$margin,
+      _ref$showXAxis = _ref.showXAxis,
+      _showXAxis = _ref$showXAxis === undefined ? true : _ref$showXAxis,
+      _ref$showYAxis = _ref.showYAxis,
+      _showYAxis = _ref$showYAxis === undefined ? true : _ref$showYAxis,
+      _ref$showValues = _ref.showValues,
+      _showValues = _ref$showValues === undefined ? true : _ref$showValues,
       _ref$barColor = _ref.barColor,
       _barColor = _ref$barColor === undefined ? 'steelblue' : _ref$barColor,
       _ref$barHoverColor = _ref.barHoverColor,
@@ -63,7 +73,13 @@ function bar() {
   var width = _width - _margin.left - _margin.right;
   var height = _height - _margin.top - _margin.bottom;
 
-  var g = svg.attr('width', _width).attr('height', _height).append('g').attr('transform', 'translate(' + _margin.left + ', ' + _margin.top + ')');
+  var g = svg.append('g').attr('transform', 'translate(' + _margin.left + ', ' + _margin.top + ')');
+
+  if (_responsive) {
+    svg.attr('viewBox', '0 0 ' + _width + ' ' + _height).attr('preserveAspectRatio', 'xMinYMin');
+  } else {
+    svg.attr('width', _width).attr('height', _height);
+  }
 
   var x = _d3.scaleBand().range([0, width]).padding(0.1);
 
@@ -84,9 +100,30 @@ function bar() {
     return height - y(d.value);
   });
 
-  g.append('g').attr('transform', 'translate(0,' + height + ')').call(_d3.axisBottom(x));
+  var keys = Object.keys(_barAttrs);
+  for (var i = 0; i < keys.length; i++) {
+    g.selectAll('.bar').attr(keys[i], function (d) {
+      return _barAttrs[keys[i]](d.value);
+    });
+  }
 
-  g.append('g').call(_d3.axisLeft(y));
+  if (_showValues) {
+    g.append('g').selectAll('text').data(data).enter().append('text').attr('class', 'bar-value-label').attr('text-anchor', 'middle').attr('x', function (d) {
+      return x(d.key);
+    }).attr('dx', x.bandwidth() / 2).attr('y', function (d) {
+      return y(d.value);
+    }).attr('dy', '-0.5em').attr('fill', 'currentColor').text(function (d) {
+      return d.value;
+    });
+  }
+
+  if (_showXAxis) {
+    g.append('g').attr('transform', 'translate(0,' + height + ')').call(_d3.axisBottom(x));
+  }
+
+  if (_showYAxis) {
+    g.append('g').call(_d3.axisLeft(y));
+  }
 
   var result = void 0;
   if (isNodeEnv()) {

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ const { addStyle } = require('./utils')
  * @param {object} margin
  * @param {boolean} showXAxis Whether to show the X axis
  * @param {boolean} showYAxis Whether to show the Y axis
+ * @param {boolean} showValues Whether to show values above each bar
  * @param {string} barColor
  * @param {string} barHoverColor
  * @param {boolean} export Whether to export to a PNG image


### PR DESCRIPTION
Hi @geekplux! I was curious if you'd be option to adding a few display customizations?

`barAttrs` allows someone to add an `attr` to every bar element. This is useful for, e.g., applying a user-defined class to every bar. 

`responsive` makes the charts automatically resize to their containing element's size, while preserving the aspect ratio. So if the browser window expands/contracts the chart will grow/shrink. If this is set to true, then the `width` and `height` options define the _initial_ size and aspect ratio (which is grown/shrunk as necessary).

`showXAxis` and `showYAxis` do exactly what you'd expect.

`showValues` shows "totals" on top of each bar, e.g.:
![image](https://user-images.githubusercontent.com/5589410/48869566-88260000-ed92-11e8-9b5b-5bffafd25a8c.png)

If you merge these, I'll add them (where applicable) to markvis-line and markvis-pie as well.

(I'll update the README, tests, and the geekplux/marked docs if you are supportive of merging this)